### PR TITLE
Fix/wordcloud progressive

### DIFF
--- a/common/changes/@visactor/vgrammar-hierarchy/fix-wordcloud-progressive_2023-07-27-06-52.json
+++ b/common/changes/@visactor/vgrammar-hierarchy/fix-wordcloud-progressive_2023-07-27-06-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix(vgrammar): wordcloud may return a empty value which cause a error\n\n",
+      "type": "patch",
+      "packageName": "@visactor/vgrammar-hierarchy"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-hierarchy",
+  "email": "dingling112@gmail.com"
+}

--- a/common/changes/@visactor/vgrammar-sankey/fix-wordcloud-progressive_2023-07-27-06-52.json
+++ b/common/changes/@visactor/vgrammar-sankey/fix-wordcloud-progressive_2023-07-27-06-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix(vgrammar): wordcloud may return a empty value which cause a error\n\n",
+      "type": "patch",
+      "packageName": "@visactor/vgrammar-sankey"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-sankey",
+  "email": "dingling112@gmail.com"
+}

--- a/common/changes/@visactor/vgrammar-wordcloud-shape/fix-wordcloud-progressive_2023-07-27-06-52.json
+++ b/common/changes/@visactor/vgrammar-wordcloud-shape/fix-wordcloud-progressive_2023-07-27-06-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix(vgrammar): wordcloud may return a empty value which cause a error\n\n",
+      "type": "patch",
+      "packageName": "@visactor/vgrammar-wordcloud-shape"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-wordcloud-shape",
+  "email": "dingling112@gmail.com"
+}

--- a/common/changes/@visactor/vgrammar-wordcloud/fix-wordcloud-progressive_2023-07-27-06-52.json
+++ b/common/changes/@visactor/vgrammar-wordcloud/fix-wordcloud-progressive_2023-07-27-06-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix(vgrammar): wordcloud may return a empty value which cause a error\n\n",
+      "type": "patch",
+      "packageName": "@visactor/vgrammar-wordcloud"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-wordcloud",
+  "email": "dingling112@gmail.com"
+}

--- a/common/changes/@visactor/vgrammar/fix-wordcloud-progressive_2023-07-27-06-52.json
+++ b/common/changes/@visactor/vgrammar/fix-wordcloud-progressive_2023-07-27-06-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix(vgrammar): wordcloud may return a empty value which cause a error\n\n",
+      "type": "patch",
+      "packageName": "@visactor/vgrammar"
+    }
+  ],
+  "packageName": "@visactor/vgrammar",
+  "email": "dingling112@gmail.com"
+}

--- a/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
+++ b/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
@@ -9,73 +9,49 @@
 
 import { transform } from '../src/wordcloud';
 
-describe.skip('wordcloud', () => {
-  test('Wordcloud generates wordcloud layout', async () => {
-    const data = [
-      { text: 'foo', size: 49, index: 0 },
-      { text: 'bar', size: 36, index: 1 },
-      { text: 'baz', size: 25, index: 2 },
-      { text: 'abc', size: 1, index: 3 }
-    ];
+test('Wordcloud should not throw error when size is 0', async () => {
+  const data = [
+    { text: 'foo', size: 49, index: 0 },
+    { text: 'bar', size: 36, index: 1 },
+    { text: 'baz', size: 25, index: 2 },
+    { text: 'abc', size: 1, index: 3 }
+  ];
 
-    const result = await transform(
-      {
-        size: [500, 500],
-        text: { field: 'text' },
-        fontSize: { field: 'size' },
-        fontSizeRange: [1, 7]
-      },
-      data
-    );
-    expect(result).toEqual([
-      {
-        angle: 0,
-        fontFamily: 'sans-serif',
-        fontSize: 7,
-        fontStyle: 'normal',
-        index: 0,
-        size: 49,
-        text: 'foo',
-        fontWeight: 'normal',
-        x: 250,
-        y: 250
-      },
-      {
-        angle: 0,
-        fontFamily: 'sans-serif',
-        fontSize: 6,
-        fontStyle: 'normal',
-        index: 1,
-        size: 36,
-        text: 'bar',
-        fontWeight: 'normal',
-        x: 251,
-        y: 242
-      },
-      {
-        angle: 0,
-        fontFamily: 'sans-serif',
-        fontSize: 5,
-        fontStyle: 'normal',
-        index: 2,
-        size: 25,
-        text: 'baz',
-        fontWeight: 'normal',
-        x: 260,
-        y: 256
-      },
-      {
-        angle: 0,
-        fontFamily: 'sans-serif',
-        fontSize: 1,
-        fontStyle: 'normal',
-        index: 3,
-        size: 1,
-        text: 'abc',
-        fontWeight: 'normal',
-        x: 249,
-        y: 255
-      }
-    ]);
-  });
+  const result = await transform(
+    {
+      size: [0, 0],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+
+  expect(result).toBe(data);
+});
+
+test('Wordcloud generates wordcloud layout', async () => {
+  const data = [
+    { text: 'foo', size: 49, index: 0 },
+    { text: 'bar', size: 36, index: 1 },
+    { text: 'baz', size: 25, index: 2 },
+    { text: 'abc', size: 1, index: 3 }
+  ];
+
+  const result = await transform(
+    {
+      size: [500, 500],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+  expect(result.length).toBe(data.length);
+  expect(result[0].fontFamily).toBe('sans-serif');
+  expect(result[0].fontSize).toBe(7);
+  expect(result[0].fontStyle).toBe('normal');
+  expect(result[0].fontWeight).toBe('normal');
+  expect(result[0].x).toBe(250);
+  expect(result[0].y).toBe(250);
 });

--- a/packages/vgrammar/src/view/mark.ts
+++ b/packages/vgrammar/src/view/mark.ts
@@ -231,7 +231,7 @@ export class Mark extends GrammarBase implements IMark {
       );
       let inputData = transformData;
 
-      if (transformData.progressive) {
+      if (transformData?.progressive) {
         this.renderContext.parameters = parameters;
         this.renderContext.beforeTransformProgressive = transformData.progressive;
         inputData = transformData.progressive.output();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vgrammar/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

wordcloud may return a empty value which cause a error of mark

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
