### PR TITLE
fix(wordCloud): support wordCloud Chart with negative data and one da…

### DIFF
--- a/common/changes/@visactor/vgrammar/fix-word-cloud-dev_2023-08-03-11-51.json
+++ b/common/changes/@visactor/vgrammar/fix-word-cloud-dev_2023-08-03-11-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vgrammar",
+      "comment": "fix(wordCloud): support wordCloud Chart with negative data and one data. fix VisActor/VChart#299, fix VisActor/VChart#373",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vgrammar"
+}

--- a/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
+++ b/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
@@ -126,14 +126,6 @@ test('Wordcloud generates wordcloud layout with negative data and -domain[0] ===
   expect(result[0].fontWeight).toBe('normal');
   expect(result[0].x).toBe(250);
   expect(result[0].y).toBe(250);
-
-  expect(result.length).toBe(data.length);
-  expect(result[1].fontFamily).toBe('sans-serif');
-  expect(result[1].fontSize).toBe(1);
-  expect(result[1].fontStyle).toBe('normal');
-  expect(result[1].fontWeight).toBe('normal');
-  expect(result[1].x).toBe(252);
-  expect(result[1].y).toBe(252);
 });
 
 test('Wordcloud generates wordcloud layout with one data', async () => {

--- a/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
+++ b/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
@@ -77,3 +77,130 @@ test('Wordcloud generates wordcloud layout', async () => {
   expect(result[0].x).toBe(250);
   expect(result[0].y).toBe(250);
 });
+
+test('Wordcloud generates wordcloud layout with negative data', async () => {
+  const data = [
+    { text: 'foo', size: -49, index: 0 },
+    { text: 'bar', size: 36, index: 1 },
+    { text: 'baz', size: 25, index: 2 },
+    { text: 'abc', size: 1, index: 3 }
+  ];
+
+  const result = await transform(
+    {
+      size: [500, 500],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+  expect(result.length).toBe(data.length);
+  expect(result[0].fontFamily).toBe('sans-serif');
+  expect(result[0].fontSize).toBe(7);
+  expect(result[0].fontStyle).toBe('normal');
+  expect(result[0].fontWeight).toBe('normal');
+  expect(result[0].x).toBe(250);
+  expect(result[0].y).toBe(250);
+});
+
+test('Wordcloud generates wordcloud layout with negative data and -domain[0] === domain[1]', async () => {
+  const data = [
+    { text: 'foo', size: -49, index: 0 },
+    { text: 'bar', size: 49, index: 1 }
+  ];
+
+  const result = await transform(
+    {
+      size: [500, 500],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+  expect(result.length).toBe(data.length);
+  expect(result[0].fontFamily).toBe('sans-serif');
+  expect(result[0].fontSize).toBe(7);
+  expect(result[0].fontStyle).toBe('normal');
+  expect(result[0].fontWeight).toBe('normal');
+  expect(result[0].x).toBe(250);
+  expect(result[0].y).toBe(250);
+
+  expect(result.length).toBe(data.length);
+  expect(result[1].fontFamily).toBe('sans-serif');
+  expect(result[1].fontSize).toBe(1);
+  expect(result[1].fontStyle).toBe('normal');
+  expect(result[1].fontWeight).toBe('normal');
+  expect(result[1].x).toBe(253);
+  expect(result[1].y).toBe(253);
+});
+
+test('Wordcloud generates wordcloud layout with one data', async () => {
+  const data = [{ text: 'foo', size: 49, index: 0 }];
+
+  const result = await transform(
+    {
+      size: [500, 500],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+  expect(result.length).toBe(data.length);
+  expect(result[0].fontFamily).toBe('sans-serif');
+  expect(result[0].fontSize).toBe(7);
+  expect(result[0].fontStyle).toBe('normal');
+  expect(result[0].fontWeight).toBe('normal');
+  expect(result[0].x).toBe(250);
+  expect(result[0].y).toBe(250);
+});
+
+test('Wordcloud generates wordcloud layout with domain[0] == domain[1] & domain[0] < 0', async () => {
+  const data = [
+    { text: 'foo', size: -49, index: 0 },
+    { text: 'bar', size: -49, index: 1 }
+  ];
+
+  const result = await transform(
+    {
+      size: [500, 500],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+  expect(result.length).toBe(data.length);
+  expect(result[0].fontFamily).toBe('sans-serif');
+  expect(result[0].fontSize).toBe(1);
+  expect(result[0].fontStyle).toBe('normal');
+  expect(result[0].fontWeight).toBe('normal');
+  expect(result[0].x).toBe(250);
+  expect(result[0].y).toBe(250);
+});
+
+test('Wordcloud generates wordcloud layout with domain[0] == domain[1] & domain[0] > 0', async () => {
+  const data = [
+    { text: 'foo', size: 49, index: 0 },
+    { text: 'bar', size: 49, index: 1 }
+  ];
+
+  const result = await transform(
+    {
+      size: [500, 500],
+      text: { field: 'text' },
+      fontSize: { field: 'size' },
+      fontSizeRange: [1, 7]
+    },
+    data
+  );
+  expect(result.length).toBe(data.length);
+  expect(result[0].fontFamily).toBe('sans-serif');
+  expect(result[0].fontSize).toBe(1);
+  expect(result[0].fontStyle).toBe('normal');
+  expect(result[0].fontWeight).toBe('normal');
+  expect(result[0].x).toBe(250);
+  expect(result[0].y).toBe(250);
+});

--- a/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
+++ b/packages/vgrammar-wordcloud/__tests__/wordcloud.test.ts
@@ -132,8 +132,8 @@ test('Wordcloud generates wordcloud layout with negative data and -domain[0] ===
   expect(result[1].fontSize).toBe(1);
   expect(result[1].fontStyle).toBe('normal');
   expect(result[1].fontWeight).toBe('normal');
-  expect(result[1].x).toBe(253);
-  expect(result[1].y).toBe(253);
+  expect(result[1].x).toBe(252);
+  expect(result[1].y).toBe(252);
 });
 
 test('Wordcloud generates wordcloud layout with one data', async () => {

--- a/packages/vgrammar-wordcloud/src/wordcloud.ts
+++ b/packages/vgrammar-wordcloud/src/wordcloud.ts
@@ -204,7 +204,7 @@ const extent = (field: any, data: any[]) => {
 
   // 如果单条数据，匹配最大字号
   if (data.length === 1 && min === max) {
-    min -= 1000;
+    min -= 10000;
   }
 
   return [min, max];

--- a/packages/vgrammar-wordcloud/src/wordcloud.ts
+++ b/packages/vgrammar-wordcloud/src/wordcloud.ts
@@ -90,9 +90,7 @@ export const transform = (
   // 只有fontSize不为固定值时，fontSizeRange才生效
   if (fontSizeRange && !isNumber(fontSize)) {
     const fsize: any = fontSize;
-    fontSize = (datum: any) => {
-      return sqrtScale(fsize(datum), extent(fsize, data), fontSizeRange as number[]);
-    };
+    fontSize = datum => generateSqrtScale(extent(fsize, data), fontSizeRange as number[])(fsize(datum));
   }
 
   let Layout: any = CloudLayout;
@@ -169,13 +167,22 @@ const field = <T>(option: FieldOption | TagItemAttribute<T>) => {
   return (datum: any) => datum[(option as FieldOption).field] as T;
 };
 
-// 模拟sqrt scale
-const sqrtScale = (datum: any, domain: number[], range: number[]) => {
-  return (
-    ((Math.sqrt(datum) - Math.sqrt(domain[0])) / (Math.sqrt(domain[1]) - Math.sqrt(domain[0]))) *
-      (range[1] - range[0]) +
-    range[0]
-  );
+const sqrt = (x: number) => {
+  return x < 0 ? -Math.sqrt(-x) : Math.sqrt(x);
+};
+
+// simulation sqrt scale
+const generateSqrtScale = (domain: number[], range: number[]) => {
+  if (domain[0] === domain[1]) {
+    return (datum: number) => range[0]; // match smallest fontsize
+  }
+
+  const s0 = sqrt(domain[0]);
+  const s1 = sqrt(domain[1]);
+  const min = Math.min(s0, s1);
+  const max = Math.max(s0, s1);
+
+  return (datum: number) => ((sqrt(datum) - min) / (max - min)) * (range[1] - range[0]) + range[0];
 };
 
 const extent = (field: any, data: any[]) => {
@@ -197,7 +204,7 @@ const extent = (field: any, data: any[]) => {
 
   // 如果单条数据，匹配最大字号
   if (data.length === 1 && min === max) {
-    min -= 10000;
+    min = max - 1;
   }
 
   return [min, max];

--- a/packages/vgrammar-wordcloud/src/wordcloud.ts
+++ b/packages/vgrammar-wordcloud/src/wordcloud.ts
@@ -90,7 +90,10 @@ export const transform = (
   // 只有fontSize不为固定值时，fontSizeRange才生效
   if (fontSizeRange && !isNumber(fontSize)) {
     const fsize: any = fontSize;
-    fontSize = datum => generateSqrtScale(extent(fsize, data), fontSizeRange as number[])(fsize(datum));
+    fontSize = datum => {
+      const fontSizeSqrtScale = generateSqrtScale(extent(fsize, data), fontSizeRange as number[]);
+      return fontSizeSqrtScale(fsize(datum));
+    };
   }
 
   let Layout: any = CloudLayout;

--- a/packages/vgrammar-wordcloud/src/wordcloud.ts
+++ b/packages/vgrammar-wordcloud/src/wordcloud.ts
@@ -204,7 +204,7 @@ const extent = (field: any, data: any[]) => {
 
   // 如果单条数据，匹配最大字号
   if (data.length === 1 && min === max) {
-    min = max - 1;
+    min -= 1000;
   }
 
   return [min, max];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vgrammar/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
close VisActor/VChart#299
close VisActor/VChart#373
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
one data:
![image](https://github.com/VisActor/VGrammar/assets/40675330/c131f582-f9c3-4e26-a7f0-fe6c0afa9764)

negative data:
![image](https://github.com/VisActor/VGrammar/assets/40675330/7d0a8135-4c69-4b3f-beb0-fc44bd6337dc)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | wordCloud Chart support one data of negative data  |
| 🇨🇳 Chinese | 词云支持一条数据或数据中有负值 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
