### PR TITLE
Test/plot

### DIFF
--- a/packages/vgrammar-plot/__tests__/marks/interval.test.ts
+++ b/packages/vgrammar-plot/__tests__/marks/interval.test.ts
@@ -1,0 +1,199 @@
+import '../util';
+import { Plot } from '../../src';
+
+test('add interval by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .interval()
+    .data([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 }
+    ])
+    .encode('x', 'x')
+    .encode('y', 'y');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ width: 316, height: 0, fill: '#6690F2' });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ width: 316, height: 590, fill: '#6690F2' });
+});
+
+test('add range interval by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .interval()
+    .data([
+      { x: 'A', y: 1, y0: 0 },
+      { x: 'B', y: 2, y0: 10 }
+    ])
+    .encode('x', 'x')
+    .encode('y', ['y0', 'y']);
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ width: 316, height: 59, fill: '#6690F2' });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ width: 316, height: 472, fill: '#6690F2' });
+});
+
+test('add grouped interval by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .interval()
+    .data([
+      { x: 'A', y: 1, cat: '0' },
+      { x: 'B', y: 2, cat: '0' },
+      { x: 'A', y: 4, cat: '1' },
+      { x: 'B', y: 8, cat: '1' }
+    ])
+    .encode('x', 'x')
+    .encode('y', 'y')
+    .encode('group', 'cat');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(4);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ width: 158, height: 0, fill: '#6690F2' });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ width: 158, fill: '#6690F2' });
+  expect(rectMark.elements[2].getGraphicItem().attribute).toMatchObject({ width: 158, fill: '#70D6A3' });
+  expect((rectMark.elements[2].getGraphicItem().attribute as any).height).toBeCloseTo(252.8571428571429);
+  expect(rectMark.elements[3].getGraphicItem().attribute).toMatchObject({ width: 158, fill: '#70D6A3' });
+});
+
+test('add interval by api in cartesian coordinate', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  }).coordinate('cartesian', { transpose: true });
+
+  plot
+    .interval()
+    .data([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 }
+    ])
+    .encode('x', 'x')
+    .encode('y', 'y');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ width: 0, height: 236, fill: '#6690F2' });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ width: 790, height: 236, fill: '#6690F2' });
+});
+
+test('add interval by api in polar coordinate', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  }).coordinate('polar');
+
+  plot
+    .interval()
+    .data([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 }
+    ])
+    .encode('x', 'x')
+    .encode('y', 'y');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('arc');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    cx: 395,
+    cy: 295,
+    innerRadius: 0,
+    outerRadius: 0,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    cx: 395,
+    cy: 295,
+    innerRadius: 295,
+    outerRadius: 0,
+    fill: '#6690F2'
+  });
+});
+
+test('add interval by api in polar coordinate', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  }).coordinate('polar', { transpose: true });
+
+  plot
+    .interval()
+    .data([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 }
+    ])
+    .encode('x', 'x')
+    .encode('y', 'y');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('arc');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    cx: 395,
+    cy: 295,
+    startAngle: 0,
+    endAngle: 0,
+    fill: '#6690F2'
+  });
+
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).innerRadius).toBeCloseTo(14.75);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).outerRadius).toBeCloseTo(132.75);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    cx: 395,
+    cy: 295,
+    endAngle: 0,
+    fill: '#6690F2'
+  });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).innerRadius).toBeCloseTo(162.25);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).outerRadius).toBeCloseTo(280.25);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).startAngle).toBeCloseTo(6.283185307179586);
+});

--- a/packages/vgrammar-plot/__tests__/marks/rect-x.test.ts
+++ b/packages/vgrammar-plot/__tests__/marks/rect-x.test.ts
@@ -1,0 +1,242 @@
+import '../util';
+import { Plot } from '../../src';
+
+test('add rect-x by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectX()
+    .data([
+      { x: 'A', x1: 'B', y: 1 },
+      { x: 'B', x1: 'C', y: 2 }
+    ])
+    .encode('x', ['x', 'x1']);
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ x: 0, y: 0, y1: 590, fill: '#6690F2' });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).x1).toBeCloseTo(263.3333333333333);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ y: 0, y1: 590, fill: '#6690F2' });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x).toBeCloseTo(263.3333333333333);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x1).toBeCloseTo(526.6666666666666);
+});
+
+test('add rect-x by api and channel x is linear', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectX()
+    .data([
+      { x: 30, y: 1 },
+      { x: 100, y: 2 }
+    ])
+    .scale('x', { type: 'linear' })
+    .encode('x', 'x');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 590,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 790,
+    height: 590,
+    fill: '#6690F2'
+  });
+});
+
+test('add rect-x by api and scale x is band', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectX()
+    .data([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 }
+    ])
+    .encode('x', 'x');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 395,
+    height: 590,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 395,
+    y: 0,
+    width: 395,
+    height: 590,
+    fill: '#6690F2'
+  });
+});
+
+test('add rect-x by api and scale x is band and the value is a array', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectX()
+    .data([
+      { x: ['A', 'B'], y: 1 },
+      { x: ['B', 'C'], y: 2 }
+    ])
+    .encode('x', 'x');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    height: 590,
+    fill: '#6690F2'
+  });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).width).toBeCloseTo(263.3333333333333);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    y: 0,
+
+    height: 590,
+    fill: '#6690F2'
+  });
+
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x).toBeCloseTo(263.3333333333333);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).width).toBeCloseTo(263.3333333333333);
+});
+
+test('add grouped rect-x by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectX()
+    .data([
+      { x: 'A', y: 1, cat: '0' },
+      { x: 'B', y: 2, cat: '0' },
+      { x: 'A', y: 4, cat: '1' },
+      { x: 'B', y: 8, cat: '1' }
+    ])
+    .encode('x', 'x')
+    .encode('group', 'cat');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(4);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 395,
+    height: 590,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 395,
+    y: 0,
+    width: 395,
+    height: 590,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[2].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 395,
+    height: 590,
+    fill: '#70D6A3'
+  });
+  expect(rectMark.elements[3].getGraphicItem().attribute).toMatchObject({
+    x: 395,
+    y: 0,
+    width: 395,
+    height: 590,
+    fill: '#70D6A3'
+  });
+});
+
+test('add rect-x by api and channel x is linear and transpose coordinate', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  }).coordinate('cartesian', { transpose: true });
+
+  plot
+    .rectX()
+    .data([
+      { x: 30, y: 1 },
+      { x: 100, y: 2 }
+    ])
+    .scale('x', { type: 'linear' })
+    .encode('x', 'x');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 590,
+    width: 590,
+    height: 0,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 590,
+    height: 590,
+    fill: '#6690F2'
+  });
+});

--- a/packages/vgrammar-plot/__tests__/marks/rect-y.test.ts
+++ b/packages/vgrammar-plot/__tests__/marks/rect-y.test.ts
@@ -1,0 +1,244 @@
+import '../util';
+import { Plot } from '../../src';
+
+test('add rect-y by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectY()
+    .data([
+      { x: 'A', x1: 'B', y: 1 },
+      { x: 'B', x1: 'C', y: 2 }
+    ])
+    .encode('y', ['x', 'x1'])
+    .scale('y', { type: 'band' });
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ x: 0, width: 790, fill: '#6690F2' });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).y).toBeCloseTo(196.66666666666666);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).height).toBeCloseTo(196.66666666666666);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ x: 0, width: 790, fill: '#6690F2' });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).y).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).height).toBeCloseTo(196.66666666666666);
+});
+
+test('add rect-y by api and channel y is linear', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectY()
+    .data([
+      { x: 30, y: 1 },
+      { x: 100, y: 2 }
+    ])
+    .encode('y', 'x');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 590,
+    width: 790,
+    height: 0,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 790,
+    height: 590,
+    fill: '#6690F2'
+  });
+});
+
+test('add rect-y by api and scale y is band', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectY()
+    .data([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 }
+    ])
+    .encode('y', 'x')
+    .scale('y', { type: 'band' });
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 295,
+    width: 790,
+    height: 295,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 790,
+    height: 295,
+    fill: '#6690F2'
+  });
+});
+
+test('add rect-y by api and scale x is band and the value is a array', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectY()
+    .data([
+      { x: ['A', 'B'], y: 1 },
+      { x: ['B', 'C'], y: 2 }
+    ])
+    .encode('y', 'x')
+    .scale('y', { type: 'band' });
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    width: 790,
+    fill: '#6690F2'
+  });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).y).toBeCloseTo(196.66666666666666);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).height).toBeCloseTo(196.66666666666666);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    y: 0,
+    width: 790,
+    fill: '#6690F2'
+  });
+
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).y).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).height).toBeCloseTo(196.66666666666666);
+});
+
+test('add grouped rect-y by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rectY()
+    .data([
+      { x: 'A', y: 1, cat: '0' },
+      { x: 'B', y: 2, cat: '0' },
+      { x: 'A', y: 4, cat: '1' },
+      { x: 'B', y: 8, cat: '1' }
+    ])
+    .encode('y', 'x')
+    .encode('group', 'cat')
+    .scale('y', { type: 'band' });
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(4);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 295,
+    width: 790,
+    height: 295,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 790,
+    height: 295,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[2].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 295,
+    width: 790,
+    height: 295,
+    fill: '#70D6A3'
+  });
+  expect(rectMark.elements[3].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 790,
+    height: 295,
+    fill: '#70D6A3'
+  });
+});
+
+test('add rect-y by api and channel x is linear and transpose coordinate', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  }).coordinate('cartesian', { transpose: true });
+
+  plot
+    .rectY()
+    .data([
+      { x: 30, y: 1 },
+      { x: 100, y: 2 }
+    ])
+    .encode('y', 'x');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 790,
+    fill: '#6690F2'
+  });
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({
+    x: 0,
+    y: 0,
+    width: 790,
+    height: 790,
+    fill: '#6690F2'
+  });
+});

--- a/packages/vgrammar-plot/__tests__/marks/rect.test.ts
+++ b/packages/vgrammar-plot/__tests__/marks/rect.test.ts
@@ -1,0 +1,140 @@
+import '../util';
+import { Plot } from '../../src';
+
+test('add rect by api and x has two fields', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rect()
+    .data([
+      { x: 'A', x1: 'B', y: 1 },
+      { x: 'B', x1: 'C', y: 2 }
+    ])
+    .encode('x', ['x', 'x1'])
+    .encode('y', 'y');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ x: 0, fill: '#6690F2' });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).y).toBeCloseTo(590);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).height).toBeCloseTo(0);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).width).toBeCloseTo(263.3333333333333);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ fill: '#6690F2' });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x).toBeCloseTo(263.3333333333333);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).y).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).width).toBeCloseTo(263.3333333333333);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).height).toBeCloseTo(590);
+});
+
+test('add rect by api', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rect()
+    .data([
+      { x: 'A', x1: 'B', y: 1 },
+      { x: 'B', x1: 'C', y: 2 }
+    ])
+    .encode('x', 'x')
+    .encode('y', 'y');
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ x: 0, fill: '#6690F2' });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).y).toBeCloseTo(590);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).height).toBeCloseTo(0);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).width).toBeCloseTo(395);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ fill: '#6690F2' });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x).toBeCloseTo(395);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).y).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).width).toBeCloseTo(395);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).height).toBeCloseTo(590);
+});
+
+test('add rect by api and y have two fields', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rect()
+    .data([
+      { x: 'A', x1: 'B', y: 1, y1: 10 },
+      { x: 'B', x1: 'C', y: 2, y1: 100 }
+    ])
+    .encode('x', ['x', 'x1'])
+    .encode('y', ['y', 'y1']);
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ x: 0, fill: '#6690F2' });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).y).toBeCloseTo(536.3636363636364);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).height).toBeCloseTo(53.636363636363626);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).width).toBeCloseTo(263.3333333333333);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ fill: '#6690F2' });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x).toBeCloseTo(263.3333333333333);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).y).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).width).toBeCloseTo(263.3333333333333);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).height).toBeCloseTo(584.040404040404);
+});
+
+test('add rect by api and y have two fields', () => {
+  const plot = new Plot({
+    width: 800,
+    height: 600
+  });
+
+  plot
+    .rect()
+    .data([
+      { x: 'A', x1: 'B', y: 1, y1: 10 },
+      { x: 'B', x1: 'C', y: 2, y1: 100 }
+    ])
+    .encode('y', 'x1')
+    .scale('y', { type: 'band' })
+    .encode('x', 'y1')
+    .scale('x', { type: 'linear' });
+
+  plot.run();
+
+  const marks = plot.view.getMarksByType('rect');
+
+  expect(marks.length).toBe(1);
+
+  const rectMark = marks[0];
+  expect(rectMark.elements.length).toEqual(2);
+  expect(rectMark.elements[0].getGraphicItem().attribute).toMatchObject({ x: 0, fill: '#6690F2' });
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).y).toBeCloseTo(295);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).height).toBeCloseTo(295);
+  expect((rectMark.elements[0].getGraphicItem().attribute as any).width).toBeCloseTo(0);
+  expect(rectMark.elements[1].getGraphicItem().attribute).toMatchObject({ fill: '#6690F2' });
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).x).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).y).toBeCloseTo(0);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).width).toBeCloseTo(790);
+  expect((rectMark.elements[1].getGraphicItem().attribute as any).height).toBeCloseTo(295);
+});

--- a/packages/vgrammar-plot/src/rect-x.ts
+++ b/packages/vgrammar-plot/src/rect-x.ts
@@ -16,6 +16,7 @@ import { isArray } from '@visactor/vutils';
 import { PlotMakType } from './enums';
 // eslint-disable-next-line no-duplicate-imports
 import { GrammarMarkType } from '@visactor/vgrammar';
+import { isContinuous } from '@visactor/vscale';
 
 export class RectXSemanticMark extends SemanticMark<PlotRectXEncoderSpec, RectXEncodeChannels> {
   static readonly type = PlotMakType.rectX;
@@ -89,12 +90,16 @@ export class RectXSemanticMark extends SemanticMark<PlotRectXEncoderSpec, RectXE
         if (isArray(xVals) && xVals.length > 1) {
           return scale.scale(xVals[1]);
         }
-        const domain = scale.domain();
-        const min = Math.min.apply(null, domain);
-        const max = Math.max.apply(null, domain);
-        const baseValue = min > 0 ? min : max < 0 ? max : 0;
 
-        return scale.scale(baseValue);
+        if (isContinuous(scale.type)) {
+          const domain = scale.domain();
+          const min = Math.min.apply(null, domain);
+          const max = Math.max.apply(null, domain);
+          const baseValue = min > 0 ? min : max < 0 ? max : 0;
+
+          return scale.scale(baseValue);
+        }
+        return scale.scale(xVals) + (scale.bandwidth?.() ?? scale.step?.() ?? 0);
       };
     }
 

--- a/packages/vgrammar-plot/src/rect-y.ts
+++ b/packages/vgrammar-plot/src/rect-y.ts
@@ -16,6 +16,7 @@ import { isArray } from '@visactor/vutils';
 // eslint-disable-next-line no-duplicate-imports
 import { GrammarMarkType } from '@visactor/vgrammar';
 import { PlotMakType } from './enums';
+import { isContinuous } from '@visactor/vscale';
 
 export class RectYSemanticMark extends SemanticMark<PlotRectYEncoderSpec, RectYEncodeChannels> {
   static readonly type = PlotMakType.rectY;
@@ -89,12 +90,15 @@ export class RectYSemanticMark extends SemanticMark<PlotRectYEncoderSpec, RectYE
         if (isArray(yVals) && yVals.length > 1) {
           return scale.scale(yVals[1]);
         }
-        const domain = scale.domain();
-        const min = Math.min.apply(null, domain);
-        const max = Math.max.apply(null, domain);
-        const baseValue = min > 0 ? min : max < 0 ? max : 0;
+        if (isContinuous(scale.type)) {
+          const domain = scale.domain();
+          const min = Math.min.apply(null, domain);
+          const max = Math.max.apply(null, domain);
+          const baseValue = min > 0 ? min : max < 0 ? max : 0;
 
-        return scale.scale(baseValue);
+          return scale.scale(baseValue);
+        }
+        return scale.scale(yVals) + (scale.bandwidth?.() ?? scale.step?.() ?? 0);
       };
     }
 

--- a/packages/vgrammar-plot/src/rect.ts
+++ b/packages/vgrammar-plot/src/rect.ts
@@ -16,6 +16,7 @@ import { SemanticMark } from './semantic-mark';
 import { GrammarMarkType } from '@visactor/vgrammar';
 import { isArray } from '@visactor/vutils';
 import { PlotMakType } from './enums';
+import { isContinuous } from '@visactor/vscale';
 
 export class RectSemanticMark extends SemanticMark<PlotRectEncoderSpec, RectEncodeChannels> {
   static readonly type = PlotMakType.rect;
@@ -83,12 +84,17 @@ export class RectSemanticMark extends SemanticMark<PlotRectEncoderSpec, RectEnco
         if (isArray(xVals) && xVals.length > 1) {
           return scale.scale(xVals[1]);
         }
-        const domain = scale.domain();
-        const min = Math.min.apply(null, domain);
-        const max = Math.max.apply(null, domain);
-        const baseValue = min > 0 ? min : max < 0 ? max : 0;
 
-        return scale.scale(baseValue);
+        if (isContinuous(scale.type)) {
+          const domain = scale.domain();
+          const min = Math.min.apply(null, domain);
+          const max = Math.max.apply(null, domain);
+          const baseValue = min > 0 ? min : max < 0 ? max : 0;
+
+          return scale.scale(baseValue);
+        }
+
+        return scale.scale(xVals) + (scale.bandwidth?.() ?? scale.step?.() ?? 0);
       };
     }
 
@@ -110,12 +116,16 @@ export class RectSemanticMark extends SemanticMark<PlotRectEncoderSpec, RectEnco
         if (isArray(yVals) && yVals.length > 1) {
           return scale.scale(yVals[1]);
         }
-        const domain = scale.domain();
-        const min = Math.min.apply(null, domain);
-        const max = Math.max.apply(null, domain);
-        const baseValue = min > 0 ? min : max < 0 ? max : 0;
+        if (isContinuous(scale.type)) {
+          const domain = scale.domain();
+          const min = Math.min.apply(null, domain);
+          const max = Math.max.apply(null, domain);
+          const baseValue = min > 0 ? min : max < 0 ? max : 0;
 
-        return scale.scale(baseValue);
+          return scale.scale(baseValue);
+        }
+
+        return scale.scale(yVals) + (scale.bandwidth?.() ?? scale.step?.() ?? 0);
       };
     }
 

--- a/packages/vgrammar/src/parse/scale.ts
+++ b/packages/vgrammar/src/parse/scale.ts
@@ -398,7 +398,7 @@ function configurePointScale(spec: PointScaleSpec, scale: IBandLikeScale, parame
 function parseFieldData(spec: ScaleData, parameters: any) {
   const field = spec.field;
   const refData = getGrammarOutput(spec.data, parameters) as any[];
-  const fieldData: any[] = [];
+  let fieldData: any[] = [];
 
   if (isArray(field)) {
     field.forEach(entry => {
@@ -406,7 +406,7 @@ function parseFieldData(spec: ScaleData, parameters: any) {
 
       refData &&
         refData.forEach(datum => {
-          fieldData.push(getter(datum));
+          fieldData = fieldData.concat(getter(datum));
         });
     });
   } else {
@@ -414,7 +414,7 @@ function parseFieldData(spec: ScaleData, parameters: any) {
 
     refData &&
       refData.forEach(datum => {
-        fieldData.push(getter(datum));
+        fieldData = fieldData.concat(getter(datum));
       });
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vgrammar/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
