### PR TITLE
Fix/wordcloud additional padding

### DIFF
--- a/common/changes/@visactor/vgrammar-core/fix-wordcloud-additional-padding_2024-01-08-13-30.json
+++ b/common/changes/@visactor/vgrammar-core/fix-wordcloud-additional-padding_2024-01-08-13-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vgrammar-core",
+      "comment": "fix(wordcloud): slove problem of addtional padding error. fix @Visactor/VChart#1873",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-core"
+}

--- a/common/changes/@visactor/vgrammar-core/fix-wordcloud-additional-padding_2024-01-08-13-37.json
+++ b/common/changes/@visactor/vgrammar-core/fix-wordcloud-additional-padding_2024-01-08-13-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vgrammar-core",
+      "comment": "feat(wordcloud): add shape of rect",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-core"
+}

--- a/packages/vgrammar-wordcloud/src/cloud-layout.ts
+++ b/packages/vgrammar-wordcloud/src/cloud-layout.ts
@@ -186,20 +186,20 @@ export class CloudLayout extends BaseLayout<ICloudLayoutOptions> implements IPro
         const distSize0 = Math.max(d.width, d.height);
         if (distSize0 <= maxSize0) {
           // 扩大尺寸满足最小字体要求 =》 按照要求扩大board
-          this.expandBoard(this._board, distSize0 / this._size[0]);
+          this.expandBoard(this._board, this._bounds, distSize0 / this._size[0]);
         } else if (this.options.clip) {
           // 扩大尺寸不满足最小字体要求，但支持裁剪 =》 按最大尺寸扩大，裁剪词语
-          this.expandBoard(this._board, maxSize0 / this._size[0]);
+          this.expandBoard(this._board, this._bounds, maxSize0 / this._size[0]);
         } else {
           // 扩大尺寸不满足最小字体要求，且不支持裁剪 =》 丢弃词语
           return true;
         }
       } else if (this._placeStatus === 3) {
         // 扩大画布
-        this.expandBoard(this._board);
+        this.expandBoard(this._board, this._bounds);
       } else {
         // 扩大画布
-        this.expandBoard(this._board);
+        this.expandBoard(this._board, this._bounds);
       }
       // 更新一次状态，下次大尺寸词语进入裁剪
       this.updateBoardExpandStatus(d.fontSize);
@@ -353,7 +353,7 @@ export class CloudLayout extends BaseLayout<ICloudLayoutOptions> implements IPro
   }
 
   // 扩充 bitmap
-  private expandBoard(board: number[], factor?: any) {
+  private expandBoard(board: number[], bounds: Bounds, factor?: any) {
     const expandedLeftWidth = (this._size[0] * (factor || 1.1) - this._size[0]) >> 5;
     let diffWidth = expandedLeftWidth * 2 > 2 ? expandedLeftWidth : 2;
     if (diffWidth % 2 !== 0) {
@@ -374,6 +374,12 @@ export class CloudLayout extends BaseLayout<ICloudLayoutOptions> implements IPro
     }
     this.insertZerosToArray(board, 0, heightArr.length + diffWidth / 2);
     this._size = [w + (diffWidth << 5), h + diffHeight];
+    if (bounds) {
+      bounds[0].x += (diffWidth << 5) / 2;
+      bounds[0].y += diffHeight / 2;
+      bounds[1].x += (diffWidth << 5) / 2;
+      bounds[1].y += diffHeight / 2;
+    }
   }
 
   // 分组扩充填充数组, 一次填充超过大概126000+会报stack overflow，worker环境下大概6w,这边取个比较小的

--- a/packages/vgrammar-wordcloud/src/shapes.ts
+++ b/packages/vgrammar-wordcloud/src/shapes.ts
@@ -80,6 +80,9 @@ export function getMaxRadiusAndCenter(shape: string, size: [number, number]) {
       center[1] = ~~(h / 1.5);
       maxRadius = Math.floor(Math.min(h / 1.5, w / 2));
       break;
+    case 'rect':
+      maxRadius = Math.floor(Math.max(h / 2, w / 2));
+      break;
     default:
       maxRadius = Math.floor(Math.min(w / 2, h / 2));
       break;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vgrammar/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/VisActor/VChart/issues/1873
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 🐞 Bugserver case id
659cb92331b6a100b15f43c2
659cba8031b6a100b15f43c3
<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution
1. 解决词云底部额外padding问题
修复前: 
![image](https://github.com/VisActor/VGrammar/assets/40675330/7a38c957-d0ba-4ed1-9ad2-d7edb7d7830b)


修复后:
![image](https://github.com/VisActor/VGrammar/assets/40675330/ed1243c5-0fe7-468b-800f-73f007db7b73)

2. 词云新增rect形状
pick from: https://code.byted.org/dp/sirius/merge_requests/591
![image](https://github.com/VisActor/VGrammar/assets/40675330/0569eb65-de81-4723-a07a-772e2d92ec27)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
4. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
