### PR TITLE
fix: aniamtion will produce error status when a mark is encode twice,…

### DIFF
--- a/common/changes/@visactor/vgrammar-core/fix-animation-empty-to_2024-04-19-10-31.json
+++ b/common/changes/@visactor/vgrammar-core/fix-animation-empty-to_2024-04-19-10-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: aniamtion will produce error status when a mark is encode twice, and to is empty\n\n",
+      "type": "none",
+      "packageName": "@visactor/vgrammar-core"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-core",
+  "email": "dingling112@gmail.com"
+}

--- a/packages/vgrammar-core/src/graph/animation/animation/update.ts
+++ b/packages/vgrammar-core/src/graph/animation/animation/update.ts
@@ -1,5 +1,5 @@
-import { array } from '@visactor/vutils';
-import { isEqual } from '@visactor/vgrammar-util';
+import { array, isNil, isEqual } from '@visactor/vutils';
+import { isEqual as isEmptyByKey } from '@visactor/vgrammar-util';
 import type { IElement } from '../../../types';
 import type { IAnimationParameters, TypeAnimation } from '../../../types/animate';
 
@@ -33,10 +33,23 @@ export const update: TypeAnimation<IElement> = (
   }
 
   Object.keys(to).forEach(key => {
-    if (isEqual(key, from, to)) {
+    if (isEmptyByKey(key, from, to)) {
       delete from[key];
       delete to[key];
     }
   });
+
+  const final = element.getFinalGraphicAttributes();
+
+  Object.keys(from).forEach(key => {
+    if (isNil(to[key])) {
+      if (isNil(final[key]) || isEqual(from[key], final[key])) {
+        delete from[key];
+      } else {
+        to[key] = final[key];
+      }
+    }
+  });
+
   return { from, to };
 };


### PR DESCRIPTION
… and to is empty

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vgrammar/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
