### PR TITLE
fix: label merge will lost data

### DIFF
--- a/common/changes/@visactor/vgrammar-core/fix-label-data-merge_2024-09-02-08-08.json
+++ b/common/changes/@visactor/vgrammar-core/fix-label-data-merge_2024-09-02-08-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vgrammar-core",
+      "comment": "fix: fix the issue of merging data in label component",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vgrammar-core"
+}

--- a/packages/vgrammar-core/src/component/label.ts
+++ b/packages/vgrammar-core/src/component/label.ts
@@ -81,7 +81,7 @@ export const generateLabelAttributes = (
       } else {
         const mergeAttributes = (attributes: any, themeDatum: any) => {
           const { data: labelData, ...restAttribute } = attributes;
-          return { data: labelData, ...merge({}, themeDatum, restAttribute) };
+          return { ...merge({}, themeDatum, restAttribute), data: labelData };
         };
         // process by order of elements
         mark.elements.forEach(element => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vgrammar/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
